### PR TITLE
Use spawn forever for async task

### DIFF
--- a/src/hooks/use_notification.rs
+++ b/src/hooks/use_notification.rs
@@ -43,7 +43,7 @@ impl UseNotificationState {
     pub fn handle_notification(&mut self, item: NotificationItem) {
         let mut inner = self.inner.clone();
         *inner.write() = item;
-        spawn(async move {
+        spawn_forever(async move {
             TimeoutFuture::new(3000).await;
             *inner.write() = NotificationItem::default();
         });


### PR DESCRIPTION
Using spawn forever allows the notification hook to maintain attention if the app changes its path to remove the notification.

Closes #157 