### PR TITLE
Fix favorite for smaller screens

### DIFF
--- a/public/styles/main.scss
+++ b/public/styles/main.scss
@@ -3248,7 +3248,7 @@ small.summary__item__value {
         height: 100vh;
         width: 100vw;
         position: absolute;
-        background: #0000004d;
+        background: rgba(0, 0, 0, 0.302);
         top: 0;
         left: 0;
         z-index: 20;

--- a/public/styles/main.scss
+++ b/public/styles/main.scss
@@ -3259,10 +3259,13 @@ small.summary__item__value {
         @extend %text-lg-font-medium;
     }
 
+    .tag {
+        padding: 0 12px;
+    }
+
     .button,
     .tab {
         @extend %text-sm-font-semibold;
-        padding: 0 12px;
     }
 
     .input {

--- a/public/styles/main.scss
+++ b/public/styles/main.scss
@@ -3248,7 +3248,7 @@ small.summary__item__value {
         height: 100vh;
         width: 100vw;
         position: absolute;
-        background: rgba(0, 0, 0, 0.3);
+        background: #0000004d;
         top: 0;
         left: 0;
         z-index: 20;
@@ -3259,13 +3259,14 @@ small.summary__item__value {
         @extend %text-lg-font-medium;
     }
 
-    .tag {
-        padding: 0 12px;
+    .button.button-favorite {
+        padding: 0;
     }
 
     .button,
     .tab {
         @extend %text-sm-font-semibold;
+        padding: 0 12px;
     }
 
     .input {

--- a/src/pages/dashboard.rs
+++ b/src/pages/dashboard.rs
@@ -171,7 +171,7 @@ pub fn Dashboard() -> Element {
                                     } else {
                                             div { class: "card__favorite",
                                                 IconButton {
-                                                    class: "button--drop bg--transparent",
+                                                    class: "button-favorite button--drop bg--transparent",
                                                     body: rsx!(
                                                         Icon { icon : Star, height : 24, width : 24, fill : if community.favorite {
                                                         "var(--state-primary-active)" } else { "var(--state-base-background)" } }

--- a/src/pages/explore.rs
+++ b/src/pages/explore.rs
@@ -149,7 +149,7 @@ pub fn Explore() -> Element {
                                         if !community.has_membership {
                                             div { class: "card__favorite",
                                                 IconButton {
-                                                    class: "button--drop bg--transparent",
+                                                    class: "button-favorite button--drop bg--transparent",
                                                     body: rsx!(
                                                         Icon { icon : Star, height : 24, width : 24, fill : if community.favorite {
                                                         "var(--state-primary-active)" } else { "var(--state-base-background)" } }


### PR DESCRIPTION
Remove padding from button class for screens with less than 1024px width, so that the favorite button can be seen. Closes #173.

### Since it removes the padding from every element that has the button class, please check that its still ok (it was ok for me but otherwise we try to fix it differently)