### PR TITLE
set explore page on '/' update routes

### DIFF
--- a/src/components/molecules/sidebar.rs
+++ b/src/components/molecules/sidebar.rs
@@ -136,7 +136,7 @@ pub fn Sidebar() -> Element {
                             on_click: move |_| {
                                 tooltip.hide();
                                 is_active.set(false);
-                                nav.push(vec![], "/explore");
+                                nav.push(vec![], "/dashboard");
                             }
                         }
                         span { class: "sidebar__action-label__not-displayed",

--- a/src/pages/dashboard.rs
+++ b/src/pages/dashboard.rs
@@ -229,79 +229,79 @@ pub fn Dashboard() -> Element {
                                 }
                             }
                         }
-                        section { class: "card card--reverse",
-                            div { class: "card__container",
-                                div { class: "card__head",
-                                    h3 { class: "card__title",
-                                        { translate!(i18,
-                                        "dashboard.cta_cards.explore.title") }
-                                    }
-                                }
-                                p { class: "card__description",
-                                    {
-                                    translate!(i18, "dashboard.cta_cards.explore.description") }
-                                }
+                        }
+                    }
+                }
+                section { class: "card card--reverse",
+                div { class: "card__container",
+                    div { class: "card__head",
+                        h3 { class: "card__title",
+                            { translate!(i18,
+                            "dashboard.cta_cards.explore.title") }
+                        }
+                    }
+                    p { class: "card__description",
+                        {
+                        translate!(i18, "dashboard.cta_cards.explore.description") }
+                    }
+                }
+                div { class: "card__cta",
+                    IconButton {
+                        class: "button--avatar",
+                        body: rsx!(Icon { icon : Compass, height : 32, width : 32, fill : "var(--fill-00)" }),
+                        on_click: move |_| {
+                            nav.push(vec![], "/");
+                        }
+                    }
+                }
+            }
+                section { class: "card card--reverse",
+                    div { class: "card__container",
+                        div { class: "card__head",
+                            h3 { class: "card__title",
+                            {translate!(i18, "dashboard.cta_cards.create.title_part_one")},
+                            span {
+                                class: "animated-text",
+                                DynamicText { words },
+                            },
+                            {translate!(i18, "dashboard.cta_cards.create.title_part_two")}
+                            },
+                        }
+                        p { class: "card__description",
+                            { translate!(i18,
+                            "dashboard.cta_cards.create.description") }
+                        }
+                        div { class: "card__head",
+                            a { class: "card__learn",
+                                { translate!(i18, "dashboard.cta_cards.create.cta") }
                             }
-                            div { class: "card__cta",
-                                IconButton {
-                                    class: "button--avatar",
-                                    body: rsx!(Icon { icon : Compass, height : 32, width : 32, fill : "var(--fill-00)" }),
-                                    on_click: move |_| {
-                                        nav.push(vec![], "/explore");
-                                    }
-                                }
+                            Icon {
+                                icon: ArrowRight,
+                                height: 20,
+                                width: 20,
+                                stroke_width: 1,
+                                fill: "var(--text-tertiary)"
                             }
                         }
-                        section { class: "card card--reverse",
-                            div { class: "card__container",
-                                div { class: "card__head",
-                                    h3 { class: "card__title",
-                                    {translate!(i18, "dashboard.cta_cards.create.title_part_one")},
-                                    span {
-                                        class: "animated-text",
-                                        DynamicText { words },
-                                    },
-                                    {translate!(i18, "dashboard.cta_cards.create.title_part_two")}
-                                    },
-                                }
-                                p { class: "card__description",
-                                    { translate!(i18,
-                                    "dashboard.cta_cards.create.description") }
-                                }
-                                div { class: "card__head",
-                                    a { class: "card__learn",
-                                        { translate!(i18, "dashboard.cta_cards.create.cta") }
-                                    }
-                                    Icon {
-                                        icon: ArrowRight,
-                                        height: 20,
-                                        width: 20,
-                                        stroke_width: 1,
-                                        fill: "var(--text-tertiary)"
-                                    }
-                                }
+                    }
+                    div { class: "card__cta",
+                        IconButton {
+                            class: "button--avatar",
+                            size: ElementSize::Big,
+                            body: rsx!(
+                                Icon { icon : AddPlus, height : 32, width : 32, stroke_width : 1.5, fill :
+                                "var(--fill-00)" }
+                            ),
+                            on_click: move |_| {
+                                tooltip.hide();
+                                nav.push(
+                                    vec![
+                                        Box::new(is_chain_available(i18, timestamp, notification)),
+                                        Box::new(is_dao_owner(i18, accounts, notification)),
+                                    ],
+                                    "/onboarding",
+                                );
                             }
-                            div { class: "card__cta",
-                                IconButton {
-                                    class: "button--avatar",
-                                    size: ElementSize::Big,
-                                    body: rsx!(
-                                        Icon { icon : AddPlus, height : 32, width : 32, stroke_width : 1.5, fill :
-                                        "var(--fill-00)" }
-                                    ),
-                                    on_click: move |_| {
-                                        tooltip.hide();
-                                        nav.push(
-                                            vec![
-                                                Box::new(is_chain_available(i18, timestamp, notification)),
-                                                Box::new(is_dao_owner(i18, accounts, notification)),
-                                            ],
-                                            "/onboarding",
-                                        );
-                                    }
-                                }
-                            }
-                        }
                         }
                     }
                 }

--- a/src/pages/explore.rs
+++ b/src/pages/explore.rs
@@ -206,59 +206,59 @@ pub fn Explore() -> Element {
                                     }
                                 }
                             }
-                            section { class: "card card--reverse",
-                                div { class: "card__container",
-                                    div { class: "card__head",
-                                        h3 { class: "card__title",
-                                            {translate!(i18, "dashboard.cta_cards.create.title_part_one")}
-                                            span {
-                                                class: "animated-text",
-                                                DynamicText { words: words },
-                                            }
-                                            {translate!(i18, "dashboard.cta_cards.create.title_part_two")}
-                                        }
-                                    }
-                                    p { class: "card__description",
-                                        { translate!(i18,
-                                        "dashboard.cta_cards.create.description") }
-                                    }
-                                    div { class: "card__head",
-                                        a { class: "card__learn",
-                                            { translate!(i18, "dashboard.cta_cards.create.cta") }
-                                        }
-                                        Icon {
-                                            icon: ArrowRight,
-                                            height: 20,
-                                            width: 20,
-                                            stroke_width: 1,
-                                            fill: "var(--text-tertiary)"
-                                        }
-                                    }
-                                }
-                                div { class: "card__cta",
-                                    IconButton {
-                                        class: "button--avatar",
-                                        size: ElementSize::Big,
-                                        body: rsx!(
-                                            Icon { icon : AddPlus, height : 32, width : 32, stroke_width : 1.5, fill :
-                                            "var(--fill-00)" }
-                                        ),
-                                        on_click: move |_| {
-                                            tooltip.hide();
-                                            nav.push(
-                                                vec![
-                                                    Box::new(is_chain_available(i18, timestamp, notification)),
-                                                    Box::new(is_dao_owner(i18, accounts, notification)),
-                                                ],
-                                                "/onboarding",
-                                            );
-                                        }
-                                    }
-                                }
-                            }
                         }
                     }
                 }
+                section { class: "card card--reverse",
+                div { class: "card__container",
+                    div { class: "card__head",
+                        h3 { class: "card__title",
+                            {translate!(i18, "dashboard.cta_cards.create.title_part_one")}
+                            span {
+                                class: "animated-text",
+                                DynamicText { words: words },
+                            }
+                            {translate!(i18, "dashboard.cta_cards.create.title_part_two")}
+                        }
+                    }
+                    p { class: "card__description",
+                        { translate!(i18,
+                        "dashboard.cta_cards.create.description") }
+                    }
+                    div { class: "card__head",
+                        a { class: "card__learn",
+                            { translate!(i18, "dashboard.cta_cards.create.cta") }
+                        }
+                        Icon {
+                            icon: ArrowRight,
+                            height: 20,
+                            width: 20,
+                            stroke_width: 1,
+                            fill: "var(--text-tertiary)"
+                        }
+                    }
+                }
+                div { class: "card__cta",
+                    IconButton {
+                        class: "button--avatar",
+                        size: ElementSize::Big,
+                        body: rsx!(
+                            Icon { icon : AddPlus, height : 32, width : 32, stroke_width : 1.5, fill :
+                            "var(--fill-00)" }
+                        ),
+                        on_click: move |_| {
+                            tooltip.hide();
+                            nav.push(
+                                vec![
+                                    Box::new(is_chain_available(i18, timestamp, notification)),
+                                    Box::new(is_dao_owner(i18, accounts, notification)),
+                                ],
+                                "/onboarding",
+                            );
+                        }
+                    }
+                }
+            }
             }
             div { class: "dashboard__footer grid-footer",
                 Paginator {

--- a/src/pages/onboarding.rs
+++ b/src/pages/onboarding.rs
@@ -88,7 +88,7 @@ pub fn Onboarding() -> Element {
     use_drop(move || attach.reset());
     use_coroutine(move |_: UnboundedReceiver<()>| async move {
         if accounts.is_active_account_an_admin() {
-            nav.push(vec![], "/");
+            nav.push(vec![], "/dashboard");
         };
 
         if is_chain_available(i18, timestamp, notification)().is_err() {

--- a/src/pages/route.rs
+++ b/src/pages/route.rs
@@ -15,7 +15,7 @@ pub enum Route {
     #[route("/login")]
     Login {},
     #[layout(Authenticated)]
-        #[route("/")]
+        #[route("/dashboard")]
         Dashboard {},
         #[route("/account")]
         Account {},
@@ -26,7 +26,7 @@ pub enum Route {
         #[route("/vos")]
         VOSIntro {},
         #[layout(Onboard)]
-            #[route("/explore")]
+            #[route("/")]
             Explore {},
             #[nest("/dao")]
                 #[nest("/:id")]

--- a/src/pages/vos_intro.rs
+++ b/src/pages/vos_intro.rs
@@ -136,7 +136,7 @@ pub fn VOSIntro() -> Element {
                         size: ElementSize::Medium,
                         status: None,
                         on_click: move |_| {
-                            nav.push(vec![], "/explore");
+                            nav.push(vec![], "/");
                         },
                     }
                 } else {
@@ -147,7 +147,7 @@ pub fn VOSIntro() -> Element {
                         variant: Variant::Tertiary,
                         status: None,
                         on_click: move |_| {
-                            nav.push(vec![], "/explore");
+                            nav.push(vec![], "/");
                         },
                     }
                 }


### PR DESCRIPTION
- CTA Cards are shown by default
- We changed /explore as the main page (there’s some confusion with the icons; we should review and decide whether to update them)